### PR TITLE
Change TTY Device file naming convention to match expected naming convention

### DIFF
--- a/driver/ch341.c
+++ b/driver/ch341.c
@@ -1474,7 +1474,7 @@ static int __init ch341_init(void)
 	if (!ch341_tty_driver)
 		return -ENOMEM;
 #endif
-	ch341_tty_driver->driver_name = "ch341_uart", ch341_tty_driver->name = "ttyCH341USB",
+	ch341_tty_driver->driver_name = "ch341_uart", ch341_tty_driver->name = "ttyUSB",
 	ch341_tty_driver->major = CH341_TTY_MAJOR, ch341_tty_driver->minor_start = 0,
 	ch341_tty_driver->type = TTY_DRIVER_TYPE_SERIAL, ch341_tty_driver->subtype = SERIAL_TYPE_NORMAL,
 #if (LINUX_VERSION_CODE < KERNEL_VERSION(5, 15, 0))

--- a/driver/ch341.c
+++ b/driver/ch341.c
@@ -1474,6 +1474,7 @@ static int __init ch341_init(void)
 	if (!ch341_tty_driver)
 		return -ENOMEM;
 #endif
+	// TODO: Also of note is the hardcoded CH341_UART name for the driver name.
 	ch341_tty_driver->driver_name = "ch341_uart", ch341_tty_driver->name = "ttyUSB",
 	ch341_tty_driver->major = CH341_TTY_MAJOR, ch341_tty_driver->minor_start = 0,
 	ch341_tty_driver->type = TTY_DRIVER_TYPE_SERIAL, ch341_tty_driver->subtype = SERIAL_TYPE_NORMAL,


### PR DESCRIPTION
Who in their right mind thinks putting the drive name in the file name is efficient or right?